### PR TITLE
Use NSPersistentContainer for Core Data setup

### DIFF
--- a/Lasp/AppDelegate.swift
+++ b/Lasp/AppDelegate.swift
@@ -15,7 +15,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     func applicationDidFinishLaunching(_ aNotification: Notification) {
         // Insert code here to initialize your application
-        let mainContext = createMainContext()
+        let mainContext = persistentContainer.viewContext
         let firstViewController = getFirstViewController()
         firstViewController.managedObjectContext = mainContext
     }


### PR DESCRIPTION
### Use NSPersistentContainer for Core Data setup

Was using an old way to setup the Core Data stack. Utilize the latest way of setting up Core Data